### PR TITLE
Fix active sidebar color and add separator

### DIFF
--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -13,3 +13,15 @@ h1 {color: #333;}
 }
 #wrapper.toggled #sidebar-wrapper {margin-left: -250px;}
 #page-content-wrapper {flex: 1; padding: 20px;}
+
+/* Active link styling in sidebar */
+#sidebar-wrapper .list-group-item.active {
+  background-color: #e9ecef;
+  color: #212529;
+  border-color: #e9ecef;
+}
+
+/* Divider under sidebar title */
+.sidebar-heading {
+  border-bottom: 1px solid #dee2e6;
+}

--- a/frontend/users.ejs
+++ b/frontend/users.ejs
@@ -13,7 +13,7 @@
             <div class="sidebar-heading p-3">MKT</div>
             <div class="list-group list-group-flush">
                 <a href="/dashboard" class="list-group-item list-group-item-action bg-light"><i class="fa fa-tachometer-alt me-2"></i>Dashboard</a>
-                <a href="/users" class="list-group-item list-group-item-action bg-light active"><i class="fa fa-users me-2"></i>Usuarios</a>
+                <a href="/users" class="list-group-item list-group-item-action active"><i class="fa fa-users me-2"></i>Usuarios</a>
             </div>
         </div>
         <div id="page-content-wrapper">


### PR DESCRIPTION
## Summary
- ensure sidebar active item keeps dark text
- add divider line under sidebar title
- remove conflicting classes from active Usuarios link

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686396570aec832ebcd1699d60776970