### PR TITLE
Add Mikrotik heartbeat monitoring

### DIFF
--- a/frontend/mikrotiks.ejs
+++ b/frontend/mikrotiks.ejs
@@ -59,6 +59,7 @@
                             <th>Cloud</th>
                             <th>Modelo</th>
                             <th>IP Interna</th>
+                            <th>Estado</th>
                             <th style="width: 150px"></th>
                         </tr>
                     </thead>
@@ -69,6 +70,7 @@
                             <td><%= m.cloud %></td>
                             <td><%= m.modelo %></td>
                             <td><%= m.ip_interna %></td>
+                            <td><%= m.status %></td>
                             <td>
                                 <a href="/mikrotiks/edit/<%= m.id %>" class="btn btn-sm btn-primary me-2">Editar</a>
                                 <form action="/mikrotiks/delete/<%= m.id %>" method="post" style="display:inline-block">

--- a/scripts/heartbeat.rsc
+++ b/scripts/heartbeat.rsc
@@ -1,0 +1,6 @@
+# Mikrotik script to send heartbeat to monitoring service
+# Replace 192.168.1.100 with your monitoring server IP or domain
+:local ddns [/ip cloud get dns-name]
+/tool fetch url="http://192.168.1.100:4000/ping?cloud=$ddns" keep-result=no
+# Schedule every 5 minutes with:
+# /system scheduler add name=heartbeat interval=5m on-event="/system script run heartbeat"


### PR DESCRIPTION
## Summary
- extend DB and backend to track Mikrotik `last_seen`
- implement monitoring server on port 4000 to receive heartbeat requests
- display device status in the Mikrotik list
- add RouterOS script for periodic heartbeat

## Testing
- `npm test` *(fails: no test specified)*
- `node backend/index.js` *(manual run, server started)*

------
https://chatgpt.com/codex/tasks/task_e_68639daf6970832eb55d0db20cd6d32a