### PR TITLE
Add per-device offline timeout

### DIFF
--- a/frontend/editMikrotik.ejs
+++ b/frontend/editMikrotik.ejs
@@ -49,6 +49,9 @@
                         <input type="text" name="ip_interna" class="form-control" value="<%= mikrotik.ip_interna %>" required>
                     </div>
                     <div class="col-md-2">
+                        <input type="number" name="offline_timeout" class="form-control" value="<%= mikrotik.offline_timeout || 5 %>" min="1" required>
+                    </div>
+                    <div class="col-md-2">
                         <button type="submit" class="btn btn-primary w-100">Guardar</button>
                     </div>
                     <div class="col-md-2">

--- a/frontend/mikrotiks.ejs
+++ b/frontend/mikrotiks.ejs
@@ -49,6 +49,9 @@
                         <input type="text" name="ip_interna" class="form-control" placeholder="IP Interna" required>
                     </div>
                     <div class="col-md-2">
+                        <input type="number" name="offline_timeout" class="form-control" placeholder="Minutos offline" value="5" min="1" required>
+                    </div>
+                    <div class="col-md-2">
                         <button type="submit" class="btn btn-success w-100">Añadir</button>
                     </div>
                 </form>
@@ -59,6 +62,7 @@
                             <th>Cloud</th>
                             <th>Modelo</th>
                             <th>IP Interna</th>
+                            <th>Timeout (min)</th>
                             <th>Estado</th>
                             <th style="width: 150px"></th>
                         </tr>
@@ -70,6 +74,7 @@
                             <td><%= m.cloud %></td>
                             <td><%= m.modelo %></td>
                             <td><%= m.ip_interna %></td>
+                            <td><%= m.offline_timeout || 5 %></td>
                             <td><%= m.status %></td>
                             <td>
                                 <a href="/mikrotiks/edit/<%= m.id %>" class="btn btn-sm btn-primary me-2">Editar</a>


### PR DESCRIPTION
## Summary
- allow configuring an inactivity timeout per Mikrotik
- store the timeout in DB and use it when deciding online/offline
- show and edit the timeout value in the Mikrotik forms

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863a5617708832e996d3159cf762ded