### PR TITLE
Add modal creation form and sortable Mikrotiks table

### DIFF
--- a/frontend/mikrotiks.ejs
+++ b/frontend/mikrotiks.ejs
@@ -5,6 +5,8 @@
     <title>MKT</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" rel="stylesheet">
+    <link href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
@@ -36,42 +38,65 @@
             </nav>
             <div class="container-fluid">
                 <h1 class="mt-4">Dispositivos Mikrotik</h1>
-                <form class="row g-3 mb-4" action="/mikrotiks/add" method="post">
-                    <div class="col-md-3">
-                        <input type="text" name="nombre" class="form-control" placeholder="Nombre" required>
+                <div class="d-flex justify-content-end mb-3">
+                    <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal">Añadir +</button>
+                </div>
+
+                <!-- Modal -->
+                <div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">
+                    <div class="modal-dialog modal-lg">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="addModalLabel">Nuevo Mikrotik</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <form action="/mikrotiks/add" method="post">
+                                <div class="modal-body">
+                                    <div class="row g-3">
+                                        <div class="col-md-3">
+                                            <input type="text" name="nombre" class="form-control" placeholder="Nombre" required>
+                                        </div>
+                                        <div class="col-md-2">
+                                            <input type="text" name="cloud" class="form-control" placeholder="Cloud" required>
+                                        </div>
+                                        <div class="col-md-3">
+                                            <input type="text" name="modelo" class="form-control" placeholder="Modelo" required>
+                                        </div>
+                                        <div class="col-md-2">
+                                            <input type="text" name="ip_interna" class="form-control" placeholder="IP Interna" required>
+                                        </div>
+                                        <div class="col-md-2">
+                                            <input type="number" name="offline_timeout" class="form-control" placeholder="Minutos offline" value="5" min="1" required>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+                                    <button type="submit" class="btn btn-primary">Crear</button>
+                                </div>
+                            </form>
+                        </div>
                     </div>
-                    <div class="col-md-2">
-                        <input type="text" name="cloud" class="form-control" placeholder="Cloud" required>
-                    </div>
-                    <div class="col-md-3">
-                        <input type="text" name="modelo" class="form-control" placeholder="Modelo" required>
-                    </div>
-                    <div class="col-md-2">
-                        <input type="text" name="ip_interna" class="form-control" placeholder="IP Interna" required>
-                    </div>
-                    <div class="col-md-2">
-                        <input type="number" name="offline_timeout" class="form-control" placeholder="Minutos offline" value="5" min="1" required>
-                    </div>
-                    <div class="col-md-2">
-                        <button type="submit" class="btn btn-success w-100">Añadir</button>
-                    </div>
-                </form>
-                <table class="table table-striped">
+                </div>
+                <table id="mikrotiksTable" class="table table-striped">
                     <thead>
                         <tr>
+                            <th>Visible</th>
                             <th>Nombre</th>
                             <th>Cloud</th>
                             <th>Modelo</th>
                             <th>IP Interna</th>
                             <th>Timeout (min)</th>
                             <th>Estado</th>
-                            <th>Visible</th>
                             <th style="width: 150px"></th>
                         </tr>
                     </thead>
                     <tbody>
                         <% mikrotiks.forEach(m => { %>
                         <tr>
+                            <td>
+                                <input type="checkbox" class="form-check-input visible-toggle" data-id="<%= m.id %>" <%= m.visible ? 'checked' : '' %>>
+                            </td>
                             <td><%= m.nombre %></td>
                             <td><%= m.cloud %></td>
                             <td><%= m.modelo %></td>
@@ -80,9 +105,6 @@
                             <td>
                                 <span class="status-dot <%= m.status === 'Online' ? 'text-success' : 'text-danger' %>">&#9679;</span>
                                 <%= m.status %>
-                            </td>
-                            <td>
-                                <input type="checkbox" class="form-check-input visible-toggle" data-id="<%= m.id %>" <%= m.visible ? 'checked' : '' %>>
                             </td>
                             <td>
                                 <a href="/mikrotiks/edit/<%= m.id %>" class="btn btn-sm btn-primary me-2">Editar</a>
@@ -97,7 +119,13 @@
             </div>
         </div>
     </div>
+    <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.colVis.min.js"></script>
     <script src="/static/script.js"></script>
 </body>
 </html>

--- a/frontend/static/script.js
+++ b/frontend/static/script.js
@@ -43,4 +43,16 @@ document.addEventListener('DOMContentLoaded', function () {
       });
     });
   }
+
+  if (document.getElementById('mikrotiksTable')) {
+    var table = new DataTable('#mikrotiksTable', {
+      dom: 'Bfrtip',
+      buttons: [
+        {
+          extend: 'colvis',
+          text: 'Columnas'
+        }
+      ]
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- refactor Mikrotiks view
  - move creation form into a Bootstrap modal opened with `Añadir +`
  - reorder columns so `Visible` is first
  - integrate DataTables and Buttons extension for sortable/column visibility table
- initialize DataTables instance from `script.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863bf13c4dc832e9afd543278daa399