### PR TITLE
Persist sidebar state and improve animation

### DIFF
--- a/frontend/static/script.js
+++ b/frontend/static/script.js
@@ -1,10 +1,16 @@
 document.addEventListener('DOMContentLoaded', function () {
   var menuToggle = document.getElementById('menu-toggle');
   var wrapper = document.getElementById('wrapper');
+  if (wrapper) {
+    if (localStorage.getItem('sidebar-collapsed') === 'true') {
+      wrapper.classList.add('toggled');
+    }
+  }
   if (menuToggle && wrapper) {
     menuToggle.addEventListener('click', function (e) {
       e.preventDefault();
       wrapper.classList.toggle('toggled');
+      localStorage.setItem('sidebar-collapsed', wrapper.classList.contains('toggled'));
     });
   }
 

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -4,20 +4,24 @@ h1 {color: #333;}
 /* Layout for sidebar navigation */
 #wrapper {display: flex; min-height: 100vh;}
 #sidebar-wrapper {
-  min-width: 250px;
   width: 250px;
+  min-width: 250px;
   min-height: 100vh;
+  transition: width 0.3s ease;
 }
 #sidebar-wrapper .list-group {
   width: 100%;
 }
 #wrapper.toggled #sidebar-wrapper {
   width: 70px;
+  min-width: 70px;
   margin-left: 0;
 }
-#wrapper.toggled #sidebar-wrapper .sidebar-heading,
 #wrapper.toggled #sidebar-wrapper .list-group-item .link-text {
   display: none;
+}
+#wrapper.toggled #sidebar-wrapper .sidebar-heading {
+  text-align: center;
 }
 #wrapper.toggled #sidebar-wrapper .list-group-item {
   text-align: center;


### PR DESCRIPTION
## Summary
- adjust sidebar min-width so it fully collapses
- keep the `MKT` title visible when collapsed
- animate sidebar width for smoother transitions
- remember sidebar toggle state in localStorage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863d8ac307c832e97d08e2738771ad7