### PR TITLE
Enable HTTPS heartbeat endpoint with token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,16 @@ node backend/index.js
 
 Se crea una base de datos SQLite en `backend/db.sqlite` con el usuario por defecto `admin`/`admin`. Inicia la aplicación y accede a `http://localhost:3000/login` para iniciar sesión y ver el dashboard.
 
+### HTTPS para los `ping`
+
+El servicio que recibe los `ping` ahora funciona sobre HTTPS. Debes colocar tus certificados en `backend/ssl/cert.pem` y `backend/ssl/key.pem` (o definir las rutas con las variables de entorno `SSL_CERT` y `SSL_KEY`).
+
+Cada dispositivo debe enviar su token junto con el nombre de nube (`cloud`). Puedes ver o editar el token desde el formulario de cada Mikrotik.
+
+Ejemplo de llamada desde el dispositivo:
+
+```
+/tool fetch url="https://TU_SERVIDOR:PUERTO/ping?cloud=example&token=TOKEN" keep-result=no
+```
+
 Desde el menú **Ajustes** es posible cambiar el puerto donde el servicio de escucha recibe los `ping` de los dispositivos Mikrotik. Al guardar un nuevo puerto el servicio se reinicia automáticamente.

--- a/backend/ssl/README.md
+++ b/backend/ssl/README.md
@@ -1,0 +1,1 @@
+Coloca aqui tu certificado `cert.pem` y tu clave `key.pem` para habilitar HTTPS en el endpoint de monitorizacion.

--- a/frontend/editMikrotik.ejs
+++ b/frontend/editMikrotik.ejs
@@ -52,6 +52,9 @@
                     <div class="col-md-2">
                         <input type="number" name="offline_timeout" class="form-control" value="<%= mikrotik.offline_timeout || 5 %>" min="1" required>
                     </div>
+                    <div class="col-md-3">
+                        <input type="text" name="token" class="form-control" value="<%= mikrotik.token %>" required>
+                    </div>
                     <div class="col-md-2">
                         <button type="submit" class="btn btn-primary w-100">Guardar</button>
                     </div>

--- a/frontend/mikrotiks.ejs
+++ b/frontend/mikrotiks.ejs
@@ -68,6 +68,9 @@
                                         <div class="col-md-2">
                                             <input type="number" name="offline_timeout" class="form-control" placeholder="Minutos offline" value="5" min="1" required>
                                         </div>
+                                        <div class="col-md-3">
+                                            <input type="text" name="token" class="form-control" placeholder="Token" required>
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="modal-footer">

--- a/scripts/heartbeat.rsc
+++ b/scripts/heartbeat.rsc
@@ -2,6 +2,7 @@
 # Replace 192.168.1.100 with your monitoring server IP or domain
 # Adjust the port to match the value configured in Ajustes
 :local ddns [/ip cloud get dns-name]
-/tool fetch url="http://192.168.1.100:4000/ping?cloud=$ddns" keep-result=no
+# Replace YOURTOKEN with the token assigned to this device
+/tool fetch url="https://192.168.1.100:4000/ping?cloud=$ddns&token=YOURTOKEN" keep-result=no
 # Schedule every 5 minutes with:
 # /system scheduler add name=heartbeat interval=5m on-event="/system script run heartbeat"


### PR DESCRIPTION
## Summary
- secure `/ping` endpoint with token parameter
- serve heartbeat listener over HTTPS
- store a token per Mikrotik device
- expose token fields in device forms
- update example heartbeat script
- add instructions for SSL certificates and tokens

## Testing
- `npm install`
- *(no tests provided)*

------
https://chatgpt.com/codex/tasks/task_e_687ded103ecc832e999f64294dedad15