### PR TITLE
Token validation for Mikrotik heartbeats

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ const express = require('express');
 const session = require('express-session');
 const sqlite3 = require('sqlite3').verbose();
 const SQLiteStore = require('connect-sqlite3')(session);
+const crypto = require('crypto');
 
 const app = express();
 const db = new sqlite3.Database(path.join(__dirname, 'db.sqlite'));
@@ -17,10 +18,13 @@ app.set('view engine', 'ejs');
 function initDb(cb) {
   db.serialize(() => {
     db.run(`CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, username TEXT UNIQUE, password TEXT)`);
-    db.run(`CREATE TABLE IF NOT EXISTS mikrotiks (id INTEGER PRIMARY KEY, nombre TEXT, cloud TEXT, modelo TEXT, ip_interna TEXT, offline_timeout INTEGER DEFAULT 5, last_seen INTEGER, visible INTEGER DEFAULT 1)`);
+    db.run(`CREATE TABLE IF NOT EXISTS mikrotiks (id INTEGER PRIMARY KEY, nombre TEXT, cloud TEXT, modelo TEXT, ip_interna TEXT, token TEXT, offline_timeout INTEGER DEFAULT 5, last_seen INTEGER, visible INTEGER DEFAULT 1)`);
     db.run(`ALTER TABLE mikrotiks ADD COLUMN last_seen INTEGER`, () => {});
     db.run(`ALTER TABLE mikrotiks ADD COLUMN offline_timeout INTEGER DEFAULT 5`, () => {});
     db.run(`ALTER TABLE mikrotiks ADD COLUMN visible INTEGER DEFAULT 1`, () => {});
+    db.run(`ALTER TABLE mikrotiks ADD COLUMN token TEXT`, () => {
+      ensureTokens();
+    });
     db.run(`CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT)`);
     db.get(`SELECT COUNT(*) as count FROM users WHERE username = ?`, ['admin'], (err, row) => {
       if (row.count === 0) {
@@ -63,6 +67,28 @@ function checkAuth(req, res, next) {
   } else {
     res.redirect('/login');
   }
+}
+
+function ensureTokens() {
+  db.all(`SELECT id FROM mikrotiks WHERE token IS NULL OR token = ''`, (err, rows) => {
+    if (err || !rows) return;
+    rows.forEach(r => {
+      const token = crypto.randomBytes(16).toString('hex');
+      db.run(`UPDATE mikrotiks SET token = ? WHERE id = ?`, [token, r.id]);
+    });
+  });
+}
+
+function verifyDeviceToken(req, res, next) {
+  const token = req.get('x-device-token');
+  const { cloud } = req.query;
+  if (!token || !cloud) return res.status(401).send('unauthorized');
+  db.get(`SELECT token FROM mikrotiks WHERE cloud = ?`, [cloud], (err, row) => {
+    if (err || !row || row.token !== token) {
+      return res.status(401).send('unauthorized');
+    }
+    next();
+  });
 }
 
 // Default route redirects to the login page
@@ -176,8 +202,9 @@ app.post('/mikrotiks/add', checkAuth, (req, res) => {
   const { nombre, cloud, modelo, ip_interna, offline_timeout } = req.body;
   if (!nombre || !cloud || !modelo || !ip_interna) return res.redirect('/mikrotiks');
   const timeout = parseInt(offline_timeout) || 5;
-  db.run(`INSERT INTO mikrotiks (nombre, cloud, modelo, ip_interna, offline_timeout, last_seen, visible) VALUES (?, ?, ?, ?, ?, ?, 1)`,
-    [nombre, cloud, modelo, ip_interna, timeout, 0], () => {
+  const token = crypto.randomBytes(16).toString('hex');
+  db.run(`INSERT INTO mikrotiks (nombre, cloud, modelo, ip_interna, token, offline_timeout, last_seen, visible) VALUES (?, ?, ?, ?, ?, ?, ?, 1)`,
+    [nombre, cloud, modelo, ip_interna, token, timeout, 0], () => {
       res.redirect('/mikrotiks');
     });
 });
@@ -273,9 +300,8 @@ app.get('/logout', (req, res) => {
 
 // Monitoring endpoint for Mikrotik heartbeats
 const monitorApp = express();
-monitorApp.get('/ping', (req, res) => {
+monitorApp.get('/ping', verifyDeviceToken, (req, res) => {
   const { cloud } = req.query;
-  if (!cloud) return res.status(400).send('missing cloud');
   const now = Date.now();
   db.run(`UPDATE mikrotiks SET last_seen = ? WHERE cloud = ?`, [now, cloud], function (err) {
     if (err || this.changes === 0) return res.status(404).send('not found');

--- a/frontend/editMikrotik.ejs
+++ b/frontend/editMikrotik.ejs
@@ -52,6 +52,10 @@
                     <div class="col-md-2">
                         <input type="number" name="offline_timeout" class="form-control" value="<%= mikrotik.offline_timeout || 5 %>" min="1" required>
                     </div>
+                    <div class="col-md-3">
+                        <label class="form-label">Token</label>
+                        <input type="text" class="form-control" value="<%= mikrotik.token %>" readonly>
+                    </div>
                     <div class="col-md-2">
                         <button type="submit" class="btn btn-primary w-100">Guardar</button>
                     </div>

--- a/frontend/mikrotiks.ejs
+++ b/frontend/mikrotiks.ejs
@@ -86,6 +86,7 @@
                             <th>Cloud</th>
                             <th>Modelo</th>
                             <th>IP Interna</th>
+                            <th>Token</th>
                             <th>Timeout (min)</th>
                             <th>Estado</th>
                             <th style="width: 150px"></th>
@@ -101,6 +102,7 @@
                             <td><%= m.cloud %></td>
                             <td><%= m.modelo %></td>
                             <td><%= m.ip_interna %></td>
+                            <td><code><%= m.token %></code></td>
                             <td><%= m.offline_timeout || 5 %></td>
                             <td>
                                 <span class="status-dot <%= m.status === 'Online' ? 'text-success' : 'text-danger' %>">&#9679;</span>


### PR DESCRIPTION
## Summary
- add token field to Mikrotik DB
- generate token when creating a Mikrotik
- verify token via middleware on `/ping`
- display token in Mikrotik list and edit view
- auto-create tokens for existing Mikrotiks and show label

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688097fb0a94832e8206d4ee80e6ab6d